### PR TITLE
update typescript depedency and isCapacitorNative fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "jasmine": "^3.1.0",
     "rxjs": "^6.2.2",
     "strip-json-comments": "~2.0.1",
-    "typescript": "~2.7.2"
+    "typescript": "~2.9.2"
   }
 }

--- a/src/app.ionic/_files/src/app/app.component.ts
+++ b/src/app.ionic/_files/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class AppComponent {
 
   initializeApp() {
     this.platform.ready().then(() => {
-      if (isCapacitorNative(window)) {
+      if (this.platform.is('capacitor')) {
         StatusBar.setStyle({
           style: StatusBarStyle.Dark
         });


### PR DESCRIPTION
Updated the typescript version to ~2.9.2 from ~2.7.2. and Fixed Has no exported member 'isCapacitorNative' (Capacitor API changed)