### PR TITLE
Fix(electron): Replace hard coded 'myapp' app name value with option.…

### DIFF
--- a/src/app.electron/index.ts
+++ b/src/app.electron/index.ts
@@ -58,7 +58,7 @@ export default function (options: ApplicationOptions) {
       scripts[`prepare.electron.${options.name}`] = `npm run postinstall.electron && tsc -p apps/electron-${options.name}/tsconfig.json`;
       scripts[`serve.electron.${options.name}.target`] = `ng serve electron-${options.name}`;
       scripts[`serve.electron.${options.name}`] = `wait-on http-get://localhost:4200/ && electron apps/electron-${options.name}/src --serve`;
-      scripts[`start.electron.${options.name}`] = `npm run prepare.electron.myapp && npm-run-all -p serve.electron.${options.name}.target serve.electron.${options.name}`;
+      scripts[`start.electron.${options.name}`] = `npm run prepare.electron.${options.name} && npm-run-all -p serve.electron.${options.name}.target serve.electron.${options.name}`;
 
       // adjust web related scripts to account for postinstall hooks
       const startWeb = scripts[`start.web.${targetAppName}`];


### PR DESCRIPTION
I followed the readme and tried out the new xplat addition - electron.   Everything works fine until the last step.  When I tried "npm run start.electron.mynewapp", I encountered an error.   Then I realized the script had a hard coded app name of 'myapp' instead of using the input appname.

This commit should fix that issue.  I followed the guidelines, built locally and ran the unit tests successfully.  