### PR TITLE
fix(generators): install dependencies for app.nativescript

### DIFF
--- a/src/app.nativescript/index.ts
+++ b/src/app.nativescript/index.ts
@@ -13,7 +13,7 @@ import {
   schematic,
   noop,
 } from '@angular-devkit/schematics';
-import { stringUtils, prerun, getNpmScope, getPrefix, addRootDeps, updatePackageScripts, updateAngularProjects, updateNxProjects, applyAppNamingConvention, getGroupByName, getAppName, missingArgument } from '../utils';
+import { stringUtils, prerun, getNpmScope, getPrefix, addRootDeps, updatePackageScripts, updateAngularProjects, updateNxProjects, applyAppNamingConvention, getGroupByName, getAppName, missingArgument, addInstall } from '../utils';
 import { Schema as ApplicationOptions } from './schema';
 
 export default function (options: ApplicationOptions) {
@@ -43,6 +43,7 @@ export default function (options: ApplicationOptions) {
       })(tree, context),
     // add root package dependencies
     (tree: Tree) => addRootDeps(tree, {nativescript: true}),
+    addInstall,
     // add start/clean scripts
     (tree: Tree) => {
       const scripts = {};

--- a/src/app.nest/index.ts
+++ b/src/app.nest/index.ts
@@ -14,7 +14,6 @@ import {
   noop,
   externalSchematic
 } from "@angular-devkit/schematics";
-import { NodePackageInstallTask } from "@angular-devkit/schematics/tasks";
 import {
   stringUtils,
   getNpmScope,
@@ -29,7 +28,8 @@ import {
   applyAppNamingConvention,
   getAppName,
   updateJsonInTree,
-  missingArgument
+  missingArgument,
+  addInstall
 } from "../utils";
 
 export default function (options: ApplicationOptions) {
@@ -99,11 +99,6 @@ export default function (options: ApplicationOptions) {
     addPostinstallers(),
     options.skipFormat ? noop() : formatFiles(options)
   ]);
-}
-
-function addInstall(host: Tree, context: SchematicContext) {
-  context.addTask(new NodePackageInstallTask());
-  return host;
 }
 
 function addAppFiles(

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -23,6 +23,7 @@ import { toFileName } from "./name-utils";
 const util = require('util');
 const xml2js = require('xml2js');
 import * as stripJsonComments from 'strip-json-comments';
+import { NodePackageInstallTask } from "@angular-devkit/schematics/tasks";
 
 export const supportedPlatforms = [
   "web",
@@ -1315,3 +1316,8 @@ export const toComponentClassName = (name: string) =>
   `${classify(name)}Component`;
 
 export const toNgModuleClassName = (name: string) => `${classify(name)}Module`;
+
+export function addInstall(host: Tree, context: SchematicContext) {
+  context.addTask(new NodePackageInstallTask());
+  return host;
+}


### PR DESCRIPTION
# Description

{N} generator was not installing dependencies when `skipInstall` was false (default value).

# How

Used `addInstall` function from app.nest