### PR TITLE
docs(generators): fix generate command typo

### DIFF
--- a/docs/xplat/getting-started/getting-started.md
+++ b/docs/xplat/getting-started/getting-started.md
@@ -53,7 +53,7 @@ ng add @nstudio/xplat
 After installing xplat tools, your default schematic collection should now be set to `@nstudio/xplat` allowing you to execute the following:
 
 ```
-nx generate app
+ng generate app
 ```
 
 Follow the prompts to generate the type of app you'd like:
@@ -63,9 +63,9 @@ Follow the prompts to generate the type of app you'd like:
 If you would like to set your default schematics to anything other than `@nstudio/xplat` you can always execute app generators via the more verbose style:
 
 ```
-nx generate @nstudio/xplat:app
+ng generate @nstudio/xplat:app
 ```
 
 ## Serving Application
 
-Run `nx serve appname` to serve the newly generated application!
+Run `ng serve appname` to serve the newly generated application!

--- a/docs/xplat/getting-started/getting-started.md
+++ b/docs/xplat/getting-started/getting-started.md
@@ -53,8 +53,9 @@ ng add @nstudio/xplat
 After installing xplat tools, your default schematic collection should now be set to `@nstudio/xplat` allowing you to execute the following:
 
 ```
-ng generate app
+nx generate app
 ```
+**Side note:** if your using a `nx` workspace with the angular presets you may need to repalace `nx` with `ng`. This also applies to the `nx serve appname` step.
 
 Follow the prompts to generate the type of app you'd like:
 
@@ -63,9 +64,9 @@ Follow the prompts to generate the type of app you'd like:
 If you would like to set your default schematics to anything other than `@nstudio/xplat` you can always execute app generators via the more verbose style:
 
 ```
-ng generate @nstudio/xplat:app
+nx generate @nstudio/xplat:app
 ```
 
 ## Serving Application
 
-Run `ng serve appname` to serve the newly generated application!
+Run `nx serve appname` to serve the newly generated application!


### PR DESCRIPTION
The command to generate a new application stated to use `nx` instead of `ng`. Using `nx` results in an error. Replacing `nx` with `ng` fixes the issue. The specific error message is 
``` shell
yarn nx generate @nstudio/xplat:app
yarn run v1.17.3
warning package.json: "dependencies" has dependency "@nstudio/xplat" with range "^8.0.6" that collides with a dependency in "devDependencies" of the same name with version "8.0.6"
$ nx generate @nstudio/xplat:app

>  NX   NOTE  Nx didn't recognize the command, forwarding on to the Angular CLI.

? What name would you like for this app? reproducible
? What type of app would like to create? nativescript    [NativeScript app]
You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

steps to reproduce:
``` shell
yarn create nx-workspace reproduce-xplat-generate-issue --preset=angular-nest --appName=reproducible
cd reproduce-xplat-generate-issue
yarn ng add @nstudio/xplat
yarn nx generate @nstudio/xplat:app
```