### PR TITLE
migrate from `opn` (deprecated) to `open`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "license-webpack-plugin": "~2.3.0",
     "ng-packagr": "~10.1.0",
     "npm-run-all": "~4.1.5",
-    "opn": "~6.0.0",
+    "open": "~6.0.0",
     "precise-commits": "~1.0.2",
     "prettier": "~2.0.0",
     "release-it": "~13.6.6",


### PR DESCRIPTION
https://www.npmjs.com/package/opn - The package has been renamed to `open`