### PR TITLE
fix(core): allow projects to be grouped under folders

### DIFF
--- a/packages/xplat-utils/src/utils/utils.ts
+++ b/packages/xplat-utils/src/utils/utils.ts
@@ -317,3 +317,11 @@ export function sanitizeCommaDelimitedArg(input: string): Array<string> {
   }
   return [];
 }
+
+export function parseProjectNameFromPath(input: string): string {
+  let projectName;
+  if (input && input.indexOf('/') > -1) {
+    projectName = input.split('/').pop();
+  }
+  return projectName;
+}

--- a/packages/xplat-utils/src/utils/utils.ts
+++ b/packages/xplat-utils/src/utils/utils.ts
@@ -319,9 +319,8 @@ export function sanitizeCommaDelimitedArg(input: string): Array<string> {
 }
 
 export function parseProjectNameFromPath(input: string): string {
-  let projectName;
   if (input && input.indexOf('/') > -1) {
-    projectName = input.split('/').pop();
+    input = input.split('/').pop();
   }
-  return projectName;
+  return input;
 }

--- a/packages/xplat/src/utils/xplat.ts
+++ b/packages/xplat/src/utils/xplat.ts
@@ -41,6 +41,7 @@ import {
   supportedNxExtraPlatforms,
   PlatformNxExtraTypes,
   supportedPlatformsWithNx,
+  parseProjectNameFromPath,
 } from '@nstudio/xplat-utils';
 import {
   updateJsonInTree,
@@ -977,9 +978,10 @@ export namespace XplatComponentHelpers {
       // building feature in shared code and in projects
       projectNames = sanitizeCommaDelimitedArg(projects);
       for (const name of projectNames) {
-        const projectParts = name.split('-');
-        const platPrefix = projectParts[0];
-        const platSuffix = projectParts.pop();
+        let projectName = parseProjectNameFromPath(name);
+        const projectParts = projectName.split('-');
+        const platPrefix = <PlatformTypes>projectParts[0];
+        const platSuffix = <PlatformTypes>projectParts.pop();
         if (
           supportedPlatforms.includes(platPrefix) &&
           !platforms.includes(platPrefix)
@@ -1102,10 +1104,7 @@ export namespace XplatFeatureHelpers {
       // building feature in shared code and in projects
       projectNames = sanitizeCommaDelimitedArg(projects);
       for (const name of projectNames) {
-        let projectName = name;
-        if (name.indexOf('/') > -1) {
-          projectName = name.split('/').pop();
-        }
+        let projectName = parseProjectNameFromPath(name);
         const projectParts = projectName.split('-');
         const platPrefix = <PlatformTypes>projectParts[0];
         const platSuffix = <PlatformTypes>projectParts.pop();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12828,6 +12828,13 @@ open@7.3.0:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+open@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.0.0.tgz#cae5e2c1a3a1bfaee0d0acc8c4b7609374750346"
+  integrity sha512-/yb5mVZBz7mHLySMiSj2DcLtMBbFPJk5JBKEkHVZFxZAPzeg3L026O0T+lbdz1B2nyDnkClRSwRQJdeVUIF7zw==
+  dependencies:
+    is-wsl "^1.1.0"
+
 opencollective-postinstall@^2.0.0, opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
@@ -12842,13 +12849,6 @@ opn@^5.3.0, opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
-
-opn@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
Projects can be nested, allowing for groups like
- apps
	- app-1
		- nativescript-app-1
		- web-app-1

This is already accounted for in one section, this commit abstracts the logic to a util and adds it to one other section.